### PR TITLE
Conform to Harvard's line-spacing requirements

### DIFF
--- a/assets/latex-base/Dissertate.cls
+++ b/assets/latex-base/Dissertate.cls
@@ -13,6 +13,54 @@
 \ProvidesClass{Dissertate}[2014/03/25 v2.0 Dissertate Class]
 \LoadClass[12pt, oneside, letterpaper]{book}
 
+%
+% Options
+%
+\RequirePackage{etoolbox}
+
+% Line spacing: dsingle/ddouble
+%   Whether to use single- or doublespacing.
+\newtoggle{DissertateSingleSpace}
+\togglefalse{DissertateSingleSpace}
+\DeclareOption{dsingle}{
+    \toggletrue{DissertateSingleSpace}
+    \ClassWarning{Dissertate}{Single-spaced mode on.}
+}
+\DeclareOption{ddouble}{\togglefalse{DissertateSingleSpace}}
+
+\ProcessOptions\relax
+
+% Line Spacing
+%   Define two line spacings: one for the body, and one that is more compressed.
+\iftoggle{DissertateSingleSpace}{
+    \newcommand{\dnormalspacing}{1.2}
+    \newcommand{\dcompressedspacing}{1.0}
+}{
+    \newcommand{\dnormalspacing}{2.0}
+    \newcommand{\dcompressedspacing}{1.2}
+}
+
+% Block quote with compressed spacing
+\let\oldquote\quote
+\let\endoldquote\endquote
+\renewenvironment{quote}
+    {\begin{spacing}{\dcompressedspacing}\oldquote}
+    {\endoldquote\end{spacing}}
+
+% Itemize with compressed spacing
+\let\olditemize\itemize
+\let\endolditemize\enditemize
+\renewenvironment{itemize}
+    {\begin{spacing}{\dcompressedspacing}\olditemize}
+    {\endolditemize\end{spacing}}
+
+% Enumerate with compressed spacing
+\let\oldenumerate\enumerate
+\let\endoldenumerate\endenumerate
+\renewenvironment{enumerate}
+    {\begin{spacing}{\dcompressedspacing}\oldenumerate}
+    {\endoldenumerate\end{spacing}}
+
 % Text layout.
 \RequirePackage[width=5.75in, letterpaper]{geometry}
 \usepackage{ragged2e}

--- a/assets/latex-base/dissertation.tex
+++ b/assets/latex-base/dissertation.tex
@@ -11,7 +11,7 @@
 % \maketitle
 % \copyrightpage
 \frontmatter
-\setstretch{1.2}
+\setstretch{\dnormalspacing}
 % \abstractpage
 % \tableofcontents
 % %\authorlist
@@ -29,7 +29,7 @@
 \include{chapters/chapter3}
 \include{chapters/conclusion}
 
-\setstretch{1.2}
+\setstretch{\dnormalspacing}
 
 % the back matter
 \backmatter

--- a/assets/schools/Harvard/style.sty
+++ b/assets/schools/Harvard/style.sty
@@ -68,11 +68,13 @@
 	\renewcommand{\headrulewidth}{0.0pt}
 	\vspace*{35pt}
 	\begin{center}
-	\Large \textcolor{SchoolColor}{\@title} \normalsize \\
-	\vspace*{20pt}
-	\scshape Abstract \\ \rm
+    	\Large \textcolor{SchoolColor}{\@title} \normalsize \\
+    	\vspace*{20pt}
+    	\scshape Abstract \\ \rm
 	\end{center}
-	\input{frontmatter/abstract}
+    \begin{spacing}{\dnormalspacing}
+    	\input{frontmatter/abstract}
+    \end{spacing}
 	\vspace*{\fill}
 	\newpage \lhead{} \rhead{}
 	\cfoot{\thepage}
@@ -87,7 +89,9 @@
 \newcommand{\acknowledgments}{
 	\chapter*{Acknowledgments}
 	\noindent
-	\input{frontmatter/thanks}
+    \begin{spacing}{\dnormalspacing}
+    	\input{frontmatter/thanks}
+    \end{spacing}
 	\vspace*{\fill} \newpage
 	\setcounter{page}{1}
 	\pagenumbering{arabic}
@@ -100,9 +104,10 @@
     \end{appendices}
     \input{endmatter/personalize}
     \clearpage
-    \bibliography{references}
-    \addcontentsline{toc}{chapter}{References}
-    \bibliographystyle{apalike2}
-    \include{endmatter/colophon}
+    \begin{spacing}{\dcompressedspacing}
+        \bibliography{references}
+        \addcontentsline{toc}{chapter}{References}
+        \bibliographystyle{apalike2}
+        \include{endmatter/colophon}
+    \end{spacing}
 }
-


### PR DESCRIPTION
1. Double-spaced abstract and body.
2. Other material (such as references) can remain single-spaced.
3. Block quotes can be single-spaced.
4. Enumerations and Itemizations can be single-spaced within individual entries.

Add option to use single-spacing throughout: [dsingle]. Produces
prettier output, but doesn't conform to Harvard's requirements.