### PR TITLE
Harvard: PDF bookmarks for abstract and table of contents.

### DIFF
--- a/assets/schools/Harvard/style.sty
+++ b/assets/schools/Harvard/style.sty
@@ -23,13 +23,15 @@
 	\maketitle
 	\copyrightpage
 	\abstractpage
-	\tableofcontents
+    \contentspage
 	% \listoffigures % optional
 	\dedicationpage
 	\acknowledgments
 }
 
 \renewcommand{\maketitle}{
+    \pagenumbering{roman}
+    \setcounter{page}{1}
 	\thispagestyle{empty}
 	\vspace*{\fill}
 	\vspace{100pt}
@@ -60,6 +62,7 @@
 }
 
 \newcommand{\abstractpage}{
+    \pdfbookmark{Abstract}{Abstract}
 	\newpage
 	\pagenumbering{roman}
 	\setcounter{page}{3}
@@ -78,10 +81,19 @@
 	\cfoot{\thepage}
 }
 
+\newcommand{\contentspage}{
+    \pdfbookmark{\contentsname}{Contents}
+    \tableofcontents
+}
+
 \newcommand{\dedicationpage}{
+    \cleardoublepage
+    \phantomsection
+    \pdfbookmark{Dedication}{Dedication}
 	\newpage \thispagestyle{fancy} \vspace*{\fill}
 	\scshape \noindent \input{frontmatter/dedication}
 	\vspace*{\fill} \newpage \rm
+    \cleardoublepage
 }
 
 \newcommand{\acknowledgments}{
@@ -105,4 +117,3 @@
     \bibliographystyle{apalike2}
     \include{endmatter/colophon}
 }
-


### PR DESCRIPTION
This makes no difference to the appearance of the printed document, but it inserts additional pdf bookmarks, which I find helpful when navigating the document on a computer.