### PR TITLE
Harvard: include certificate at beginning of dissertation.

### DIFF
--- a/assets/latex-base/Dissertate.cls
+++ b/assets/latex-base/Dissertate.cls
@@ -13,6 +13,24 @@
 \ProvidesClass{Dissertate}[2014/03/25 v2.0 Dissertate Class]
 \LoadClass[12pt, oneside, letterpaper]{book}
 
+%
+% Options
+%
+\RequirePackage{etoolbox}
+
+% Draft: ddraft/dfinal
+%   In draft mode, the following changes are made:
+%     1. Certificate is not included at the beginning of the dissertation.
+\newtoggle{DissertateDraft}
+\togglefalse{DissertateDraft}
+\DeclareOption{ddraft}{
+    \toggletrue{DissertateDraft}
+    \ClassWarning{Dissertate}{Draft mode on.}
+}
+\DeclareOption{dfinal}{\togglefalse{DissertateDraft}}
+
+\ProcessOptions\relax
+
 % Text layout.
 \RequirePackage[width=5.75in, letterpaper]{geometry}
 \usepackage{ragged2e}

--- a/assets/latex-base/dissertation.tex
+++ b/assets/latex-base/dissertation.tex
@@ -2,7 +2,8 @@
 %!TEX encoding = UTF-8 Unicode
 
 
-\documentclass{Dissertate}
+\documentclass[ddraft]{Dissertate}
+% Remove [ddraft] option before generating final version for submission.
 
 \begin{document}
 

--- a/assets/schools/Harvard/style.sty
+++ b/assets/schools/Harvard/style.sty
@@ -19,6 +19,7 @@
 % Formatting guidelines found in:
 % http://www.gsas.harvard.edu/publications/form_of_the_phd_dissertation.php
 \renewcommand{\frontmatter}{
+    \certificatepage
 	\input{frontmatter/personalize}
 	\maketitle
 	\copyrightpage
@@ -27,6 +28,18 @@
 	% \listoffigures % optional
 	\dedicationpage
 	\acknowledgments
+}
+
+% Diploma Acceptance Certificate
+\iftoggle{DissertateDraft}{ % No certificate page in draft
+    \newcommand{\certificatepage}{}
+}{                          % Insert certificate page in final version
+    \RequirePackage{pdfpages}
+    \newcommand{\certificatepage}{
+        \pagenumbering{roman}
+        \setcounter{page}{0}
+        \includepdf{certificate.pdf}
+    }
 }
 
 \renewcommand{\maketitle}{
@@ -105,4 +118,3 @@
     \bibliographystyle{apalike2}
     \include{endmatter/colophon}
 }
-


### PR DESCRIPTION
If the option `[ddraft]` is not supplied to the `Dissertate` class, it will look for `certificate.pdf` in the base directory and insert it before the title page.

Harvard requires the "Dissertation Acceptance Certificate" to be included before the title page, but simply merging it in after-the-fact (with `pdftk`, for example) can mess up the page indexing in the electronic version of the PDF. The print version will still be fine, but in the PDF index, the abstract will be addressed by `3` instead of `iii`. Using `pdfpages` to insert the certificate during compilation fixes this problem.