### PR TITLE
added the ability to have possessive/genitive citations (e.g., Pacer and Suchow's paper on proselint)

### DIFF
--- a/assets/latex-base/Dissertate.cls
+++ b/assets/latex-base/Dissertate.cls
@@ -124,6 +124,22 @@
 \renewcommand*{\chapterheadstartvskip}{\vspace*{-0.5\baselineskip}}
 \renewcommand*{\chapterheadendvskip}{\vspace{1.3\baselineskip}}
 
+% make \citepos possible by extending natbib
+
+\makeatletter
+% make numeric styles use name format
+\patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@nmfmt{\NAT@nm}}{}{}
+% define \citepos just like \citet
+\DeclareRobustCommand\citepos
+  {\begingroup
+   \let\NAT@nmfmt\NAT@posfmt% ...except with a different name format
+   \NAT@swafalse\let\NAT@ctype\z@\NAT@partrue
+   \@ifstar{\NAT@fulltrue\NAT@citetp}{\NAT@fullfalse\NAT@citetp}}
+\let\NAT@orig@nmfmt\NAT@nmfmt
+\def\NAT@posfmt#1{\NAT@orig@nmfmt{#1's}}
+\makeatother
+
+
 % An environment for paragraph-style section.
 \providecommand\newthought[1]{%
    \addvspace{1.0\baselineskip plus 0.5ex minus 0.2ex}%


### PR DESCRIPTION
Add the ability to cite papers in a possessive form (which is otherwise impossible to do with natbib). 

Fix drawn from: http://tex.stackexchange.com/questions/125690/bibtex-and-genitive-possessive-s-the-proper-way-to-obtain-kurans-1989-mo

really this should be built into natbib, but that hasn't been touched since 2010, so I'm not holding my breath, and I don't want us to be shipping our own incompatible version of natbib, so this seemed like the most sensible place to put it. 